### PR TITLE
Video support and other changes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,9 @@ See a list of original features [here](http://www.minigal.dk/minigal-nano.html)
 ## Features of MiniGal Nano NG
 
 ### Implemented
+* thumbnail caching
+* reduced-size image preview
+* HTML5 video support (.mp4)
 
 ### To come
-* thumbnail caching
+* fullscreen view

--- a/src/config_default.php
+++ b/src/config_default.php
@@ -39,6 +39,8 @@ $label_loading 			= "Loading..."; //Thumbnail loading text
 //ADVANCED SETTINGS
 $thumb_size 			= 120; //Thumbnail height/width (square thumbs). Changing this will most likely require manual altering of the template file to make it look properly! 
 $small_size 			= 1024; //Size (width) of the images displayed in the gallery. Images are scaled proportionally
+$thumb_path 			= "/tmp/thumbnails"; //Thumbnail path. Must be writable by the httpd user.
+$small_path 			= "/tmp/small"; //Preview image path. Must be writable by the httpd user.
 $label_max_length 		= 30; //Maximum chars of a folder name that will be displayed on the folder thumbnail  
 $display_exif			= 0;
 ?>

--- a/src/config_default.php
+++ b/src/config_default.php
@@ -38,6 +38,7 @@ $label_loading 			= "Loading..."; //Thumbnail loading text
 
 //ADVANCED SETTINGS
 $thumb_size 			= 120; //Thumbnail height/width (square thumbs). Changing this will most likely require manual altering of the template file to make it look properly! 
+$small_size 			= 1024; //Size (width) of the images displayed in the gallery. Images are scaled proportionally
 $label_max_length 		= 30; //Maximum chars of a folder name that will be displayed on the folder thumbnail  
 $display_exif			= 0;
 ?>

--- a/src/createsmall.php
+++ b/src/createsmall.php
@@ -17,7 +17,7 @@ Please enjoy this free script!
 
 USAGE EXAMPLE:
 File: createsmall.php
-Example: <img src="createsmall.php?filename=photo.jpg&amp;width=100&amp;height=100">
+Example: <img src="createsmall.php?filename=photo.jpg&amp;size=100">
 */
 //  error_reporting(E_ALL);
 
@@ -39,7 +39,7 @@ function create_thumb($filename, $outfile, $size = 1024) {
     }
 
     // Rotate JPG pictures
-    if (preg_match("/.jpg$|.jpeg$/i", $filename)) {
+    if (preg_match("/\.jpg$|\.jpeg$/i", $filename)) {
         if (function_exists('exif_read_data') && function_exists('imagerotate')) {
             $exif = exif_read_data($filename);
             $ort = $exif['IFD0']['Orientation'];
@@ -57,36 +57,24 @@ function create_thumb($filename, $outfile, $size = 1024) {
     }
 
     $target = ImageCreatetruecolor($width,$height);
-    if (preg_match("/.jpg$|.jpeg$/i", $filename)) $source = ImageCreateFromJPEG($filename);
-    if (preg_match("/.gif$/i", $filename)) $source = ImageCreateFromGIF($filename);
-    if (preg_match("/.png$/i", $filename)) $source = ImageCreateFromPNG($filename);
+    if (preg_match("/\.jpg$|\.jpeg$/i", $filename)) $source = ImageCreateFromJPEG($filename);
+    if (preg_match("/\.gif$/i", $filename)) $source = ImageCreateFromGIF($filename);
+    if (preg_match("/\.png$/i", $filename)) $source = ImageCreateFromPNG($filename);
     imagecopyresampled($target, $source, 0, 0, 0, 0, $width, $height, $width_orig, $height_orig);
     imagedestroy($source);
 
-    if (preg_match("/.jpg$|.jpeg$/i", $filename)) ImageJPEG($target,$outfile,90);
-    if (preg_match("/.gif$/i", $filename)) ImageGIF($target,$outfile,90);
-    if (preg_match("/.png$/i", $filename)) ImageJPEG($target,$outfile,90); // Using ImageJPEG on purpose
+    if (preg_match("/\.jpg$|\.jpeg$/i", $filename)) ImageJPEG($target,$outfile,90);
+    if (preg_match("/\.gif$/i", $filename)) ImageGIF($target,$outfile,90);
+    if (preg_match("/\.png$/i", $filename)) ImageJPEG($target,$outfile,90); // Using ImageJPEG on purpose
     imagedestroy($target);
 }
 
-
-$extension = preg_replace('.*\.\w*$', '', $_GET['filename']);
-
-if (preg_match("/.jpg$|.jpeg$/i", $_GET['filename'])) {
-    header('Content-type: image/jpeg');
-    $cleanext = 'jpeg';
-}
-if (preg_match("/.gif$/i", $_GET['filename'])) {
-    header('Content-type: image/gif');
-    $cleanext = 'gif';
-}
-if (preg_match("/.png$/i", $_GET['filename'])) {
-    header('Content-type: image/png');
-    $cleanext = 'png';
-}
+$_GET['filename'] = "./" . $_GET['filename'];
+$_GET['size']=filter_var($_GET['size'], FILTER_VALIDATE_INT);
+if ($_GET['size'] == false) $_GET['size'] = 1024;
 
 // Display error image if file isn't found
-if (!is_file($_GET['filename'])) {
+if (preg_match("/\.\.\//i", $_GET['filename']) || !is_file($_GET['filename'])) {
     header('Content-type: image/jpeg');
     $errorimage = ImageCreateFromJPEG('images/questionmark.jpg');
     ImageJPEG($errorimage,null,90);
@@ -99,16 +87,27 @@ if (substr(decoct(fileperms($_GET['filename'])), -1, strlen(fileperms($_GET['fil
     ImageJPEG($errorimage,null,90);
 }
 
+$extension = preg_replace('.*\.\w*$', '', $_GET['filename']);
+
+if (preg_match("/\.jpg$|\.jpeg|\.png$$/i", $_GET['filename'])) {
+    header('Content-type: image/jpeg');
+    $cleanext = 'jpeg';
+}
+if (preg_match("/\.gif$/i", $_GET['filename'])) {
+    header('Content-type: image/gif');
+    $cleanext = 'gif';
+}
+
 // Create paths for different picture versions
 $md5sum = md5($_GET['filename']);
-$small = "small/" . $md5sum;
+$small = "small/" . $md5sum . "_" . $size . "." . $cleanext;
 
 
 if (!is_file($small)) {
     create_thumb($_GET['filename'], $small, $_GET['size']);
 }
 
-if ( $cleanext == 'jpeg' || $cleanext == 'png') {
+if ( $cleanext == 'jpeg') {
     $img = ImageCreateFromJPEG($small);
     ImageJPEG($img,null,90);
 } else if ( $cleanext == 'gif') {

--- a/src/createsmall.php
+++ b/src/createsmall.php
@@ -21,6 +21,9 @@ Example: <img src="createsmall.php?filename=photo.jpg&amp;size=100">
 */
 //  error_reporting(E_ALL);
 
+require("config_default.php");
+include("config.php");
+
 function create_thumb($filename, $outfile, $size = 1024) {
     // Define variables
     $target = "";
@@ -100,9 +103,9 @@ if (preg_match("/\.gif$/i", $_GET['filename'])) {
 
 // Create paths for different picture versions
 $md5sum = md5($_GET['filename']);
-$small = "/tmp/small/" . $md5sum . "_" . $_GET['size'] . "." . $cleanext;
-if(!file_exists("/tmp/small"))
-    mkdir("/tmp/small");
+$small = $small_path . "/" . $md5sum . "_" . $_GET['size'] . "." . $cleanext;
+if(!file_exists($small_path))
+    mkdir($small_path);
 
 
 if (!is_file($small)) {

--- a/src/createsmall.php
+++ b/src/createsmall.php
@@ -100,7 +100,9 @@ if (preg_match("/\.gif$/i", $_GET['filename'])) {
 
 // Create paths for different picture versions
 $md5sum = md5($_GET['filename']);
-$small = "small/" . $md5sum . "_" . $size . "." . $cleanext;
+$small = "/tmp/small/" . $md5sum . "_" . $_GET['size'] . "." . $cleanext;
+if(!file_exists("/tmp/small"))
+    mkdir("/tmp/small");
 
 
 if (!is_file($small)) {

--- a/src/createthumb.php
+++ b/src/createthumb.php
@@ -21,6 +21,9 @@ Example: <img src="createthumb.php?filename=photo.jpg&amp;width=100&amp;height=1
 */
 //  error_reporting(E_ALL);
 
+require("config_default.php");
+include("config.php");
+
 function create_thumb($filename, $outfile, $size = 120) {
     // Define variables
     $target = "";
@@ -115,9 +118,9 @@ if (preg_match("/.gif$/i", $_GET['filename'])) {
 
 // Create paths for different picture versions
 $md5sum = md5($_GET['filename']);
-$thumbnail = "/tmp/thumbnails/" . $md5sum . "_" . $_GET['size'] . "." . $cleanext;
-if(!file_exists("/tmp/thumbnails"))
-    mkdir("/tmp/thumbnails");
+$thumbnail = $thumb_path . "/" . $md5sum . "_" . $_GET['size'] . "." . $cleanext;
+if(!file_exists($thumb_path))
+    mkdir($thumb_path);
 
 if (!is_file($thumbnail)) {
     create_thumb($_GET['filename'], $thumbnail, $_GET['size']);

--- a/src/createthumb.php
+++ b/src/createthumb.php
@@ -28,8 +28,8 @@ function create_thumb($filename, $outfile, $size = 120) {
     $yoord = 0;
 
     if (preg_match("/\.mp4$|\.mts$|\.mov$|\.m4v$|\.m4a$|\.aiff$|\.avi$|\.caf$|\.dv$|\.qtz$|\.flv$/i", $filename)) {
-	exec ("ffmpegthumbnailer -i " . escapeshellarg($filename) . " -o " . escapeshellarg($outfile) . " -s " . escapeshellarg($size) . " -c jpeg -a -f");
-	return;
+        exec("ffmpegthumbnailer -i " . escapeshellarg($filename) . " -o " . escapeshellarg($outfile) . " -s " . escapeshellarg($size) . " -c jpeg -a -f");
+        return;
     }
 
     $imgsize = GetImageSize($filename);
@@ -97,7 +97,7 @@ if (substr(decoct(fileperms($_GET['filename'])), -1, strlen(fileperms($_GET['fil
     exit;
 }
 
-$extension = preg_replace('.*\.\w*$', '', $_GET['filename']);
+// $extension = preg_replace('.*\.\w*$', '', $_GET['filename']);
 
 if (preg_match("/.gif$/i", $_GET['filename'])) {
     header('Content-type: image/gif');
@@ -115,8 +115,9 @@ if (preg_match("/.gif$/i", $_GET['filename'])) {
 
 // Create paths for different picture versions
 $md5sum = md5($_GET['filename']);
-$thumbnail = "thumbnails/" . $md5sum . "_" . $size . "." . $cleanext;
-
+$thumbnail = "/tmp/thumbnails/" . $md5sum . "_" . $_GET['size'] . "." . $cleanext;
+if(!file_exists("/tmp/thumbnails"))
+    mkdir("/tmp/thumbnails");
 
 if (!is_file($thumbnail)) {
     create_thumb($_GET['filename'], $thumbnail, $_GET['size']);

--- a/src/createthumb.php
+++ b/src/createthumb.php
@@ -27,6 +27,11 @@ function create_thumb($filename, $outfile, $size = 120) {
     $xoord = 0;
     $yoord = 0;
 
+    if (preg_match("/\.mp4$|\.mts$|\.mov$|\.m4v$|\.m4a$|\.aiff$|\.avi$|\.caf$|\.dv$|\.qtz$|\.flv$/i", $filename)) {
+	exec ("ffmpegthumbnailer -i " . escapeshellarg($filename) . " -o " . escapeshellarg($outfile) . " -s " . escapeshellarg($size) . " -c jpeg -a -f");
+	return;
+    }
+
     $imgsize = GetImageSize($filename);
     $width = $imgsize[0];
     $height = $imgsize[1];
@@ -39,7 +44,7 @@ function create_thumb($filename, $outfile, $size = 120) {
     }
 
     // Rotate JPG pictures
-    if (preg_match("/.jpg$|.jpeg$/i", $filename)) {
+    if (preg_match("/\.jpg$|\.jpeg$/i", $filename)) {
         if (function_exists('exif_read_data') && function_exists('imagerotate')) {
             $exif = exif_read_data($filename);
             $ort = $exif['IFD0']['Orientation'];
@@ -57,39 +62,30 @@ function create_thumb($filename, $outfile, $size = 120) {
     }
 
     $target = ImageCreatetruecolor($size,$size);
-    if (preg_match("/.jpg$|.jpeg$/i", $filename)) $source = ImageCreateFromJPEG($filename);
-    if (preg_match("/.gif$/i", $filename)) $source = ImageCreateFromGIF($filename);
-    if (preg_match("/.png$/i", $filename)) $source = ImageCreateFromPNG($filename);
+    if (preg_match("/\.jpg$|\.jpeg$/i", $filename)) $source = ImageCreateFromJPEG($filename);
+    if (preg_match("/\.gif$/i", $filename)) $source = ImageCreateFromGIF($filename);
+    if (preg_match("/\.png$/i", $filename)) $source = ImageCreateFromPNG($filename);
     imagecopyresampled($target,$source,0,0,$xoord,$yoord,$size,$size,$width,$height);
     imagedestroy($source);
 
-    if (preg_match("/.jpg$|.jpeg$/i", $filename)) ImageJPEG($target,$outfile,90);
-    if (preg_match("/.gif$/i", $filename)) ImageGIF($target,$outfile,90);
-    if (preg_match("/.png$/i", $filename)) ImageJPEG($target,$outfile,90); // Using ImageJPEG on purpose
+    if (preg_match("/\.jpg$|\.jpeg$/i", $filename)) ImageJPEG($target,$outfile,90);
+    if (preg_match("/\.gif$/i", $filename)) ImageGIF($target,$outfile,90);
+    if (preg_match("/\.png$/i", $filename)) ImageJPEG($target,$outfile,90); // Using ImageJPEG on purpose
     imagedestroy($target);
 }
 
 
-$extension = preg_replace('.*\.\w*$', '', $_GET['filename']);
-
-if (preg_match("/.jpg$|.jpeg$/i", $_GET['filename'])) {
-    header('Content-type: image/jpeg');
-    $cleanext = 'jpeg';
-}
-if (preg_match("/.gif$/i", $_GET['filename'])) {
-    header('Content-type: image/gif');
-    $cleanext = 'gif';
-}
-if (preg_match("/.png$/i", $_GET['filename'])) {
-    header('Content-type: image/png');
-    $cleanext = 'png';
-}
+$_GET['filename'] = "./" . $_GET['filename'];
+$_GET['size']=filter_var($_GET['size'], FILTER_VALIDATE_INT);
+if ($_GET['size'] == false) $_GET['size'] = 120;
 
 // Display error image if file isn't found
-if (!is_file($_GET['filename'])) {
+if (preg_match("/\.\.\//i", $_GET['filename']) || !is_file($_GET['filename'])) {
     header('Content-type: image/jpeg');
     $errorimage = ImageCreateFromJPEG('images/questionmark.jpg');
     ImageJPEG($errorimage,null,90);
+    imagedestroy($errorimg);
+    exit;
 }
 
 // Display error image if file exists, but can't be opened
@@ -97,25 +93,40 @@ if (substr(decoct(fileperms($_GET['filename'])), -1, strlen(fileperms($_GET['fil
     header('Content-type: image/jpeg');
     $errorimage = ImageCreateFromJPEG('images/cannotopen.jpg');
     ImageJPEG($errorimage,null,90);
+    imagedestroy($errorimg);
+    exit;
+}
+
+$extension = preg_replace('.*\.\w*$', '', $_GET['filename']);
+
+if (preg_match("/.gif$/i", $_GET['filename'])) {
+    header('Content-type: image/gif');
+    $cleanext = 'gif';
+} else if (preg_match("/\.jpg$|\.jpeg$|\.png$|\.mp4$|\.mts$|\.mov$|\.m4v$|\.m4a$|\.aiff$|\.avi$|\.caf$|\.dv$|\.qtz$|\.flv$/i", $_GET['filename'])) {
+    header('Content-type: image/jpeg');
+    $cleanext = 'jpeg';
+} else {
+    header('Content-type: image/jpeg');
+    $errorimage = ImageCreateFromJPEG('images/cannotopen.jpg');
+    ImageJPEG($errorimage,null,90);
+    imagedestroy($errorimg);
+    exit;
 }
 
 // Create paths for different picture versions
 $md5sum = md5($_GET['filename']);
-$thumbnail = "thumbnails/" . $md5sum;
+$thumbnail = "thumbnails/" . $md5sum . "_" . $size . "." . $cleanext;
 
 
 if (!is_file($thumbnail)) {
     create_thumb($_GET['filename'], $thumbnail, $_GET['size']);
 }
 
-if ( $cleanext == 'jpeg' || $cleanext == 'png') {
-    $img = ImageCreateFromJPEG($thumbnail);
-    ImageJPEG($img,null,90);
-} else if ( $cleanext == 'gif') {
+if ( $cleanext == 'gif') {
     $img = ImageCreateFromGIF($thumbnail);
     ImageGIF($img,null,90);
 } else {
-    $img = ImageCreateFromJPEG('images/cannotopen.jpg');
+    $img = ImageCreateFromJPEG($thumbnail);
     ImageJPEG($img,null,90);
 }
 imagedestroy($img);

--- a/src/index.php
+++ b/src/index.php
@@ -227,7 +227,7 @@ if (file_exists($currentdir ."/captions.txt"))
                             "name" => $file,
                             "date" => filemtime($currentdir . "/" . $file),
                             "size" => filesize($currentdir . "/" . $file),
-                            "html" => "<li><a href='" . $currentdir . "/" . $file . "&amp;size=$small_size' rel='lightbox[billeder]' title='$img_captions[$file]'><span></span><img src='" . GALLERY_ROOT . "createthumb.php?filename=" . $thumbdir . "/" . $file . "&amp;size=$thumb_size' alt='$label_loading' /></a></li>");
+                            "html" => "<li><a href='" . $currentdir . "/" . $file . "' rel='lightbox[billeder]' title='$img_captions[$file]'><span></span><img src='" . GALLERY_ROOT . "createthumb.php?filename=" . $thumbdir . "/" . $file . "&amp;size=$thumb_size' alt='$label_loading' /></a></li>");
                     }
                     // Other filetypes
                     $extension = "";

--- a/src/index.php
+++ b/src/index.php
@@ -32,7 +32,7 @@ Please enjoy this free script!
 */
 
 $version = "0.3.5";
-ini_set("memory_limit","256M");
+ini_set("memory_limit","512M");
 
 require("config_default.php");
 include("config.php");
@@ -70,8 +70,8 @@ function is_directory($filepath) {
 function padstring($name, $length) {
     global $label_max_length;
     if (!isset($length)) $length = $label_max_length;
-    if (strlen($name) > $length) {
-      return substr($name,0,$length) . "...";
+    if (mb_strlen($name) > $length) {
+      return mb_substr($name,0,$length) . "...";
    } else return $name;
 }
 function getfirstImage($dirname) {
@@ -81,8 +81,8 @@ function getfirstImage($dirname) {
     {
         while(false !== ($file = readdir($handle)))
         {
-            $lastdot = strrpos($file, '.');
-            $extension = substr($file, $lastdot + 1);
+            $lastdot = mb_strrpos($file, '.');
+            $extension = mb_substr($file, $lastdot + 1);
             if ($file[0] != '.' && in_array($extension, $ext)) break;
         }
         $imageName = $file;
@@ -110,17 +110,17 @@ function readEXIF($file) {
 
         $exif_date = exif_read_data ($file,'IFD0' ,0 );
         $edate = $exif_date['DateTime'];
-        if (strlen($emodel) > 0 OR strlen($efocal) > 0 OR strlen($eexposuretime) > 0 OR strlen($efnumber) > 0 OR strlen($eiso) > 0) $exif_data .= "::";
-        if (strlen($emodel) > 0) $exif_data .= "$emodel";
+        if (mb_strlen($emodel) > 0 OR mb_strlen($efocal) > 0 OR mb_strlen($eexposuretime) > 0 OR mb_strlen($efnumber) > 0 OR mb_strlen($eiso) > 0) $exif_data .= "::";
+        if (mb_strlen($emodel) > 0) $exif_data .= "$emodel";
         if ($efocal > 0) $exif_data .= " | $efocal" . "mm";
-        if (strlen($eexposuretime) > 0) $exif_data .= " | $eexposuretime" . "s";
+        if (mb_strlen($eexposuretime) > 0) $exif_data .= " | $eexposuretime" . "s";
         if ($efnumber > 0) $exif_data .= " | f$efnumber";
-        if (strlen($eiso) > 0) $exif_data .= " | ISO $eiso";
+        if (mb_strlen($eiso) > 0) $exif_data .= " | ISO $eiso";
         return($exif_data);
 }
 function checkpermissions($file) {
     global $messages;
-    if (substr(decoct(fileperms($file)), -1, strlen(fileperms($file))) < 4 OR substr(decoct(fileperms($file)), -3,1) < 4) $messages = "At least one file or folder has wrong permissions. Learn how to <a href='http://minigal.dk/faq-reader/items/how-do-i-change-file-permissions-chmod.html' target='_blank'>set file permissions</a>";
+    if (mb_substr(decoct(fileperms($file)), -1, mb_strlen(fileperms($file))) < 4 OR mb_substr(decoct(fileperms($file)), -3,1) < 4) $messages = "At least one file or folder has wrong permissions. Learn how to <a href='http://minigal.dk/faq-reader/items/how-do-i-change-file-permissions-chmod.html' target='_blank'>set file permissions</a>";
 }
 
 //-----------------------
@@ -129,12 +129,13 @@ function checkpermissions($file) {
 if (ini_get('allow_url_fopen') == "1") {
     $file = @fopen ("http://www.minigal.dk/minigalnano_version.php", "r");
     $server_version = fgets ($file, 1024);
-    if (strlen($server_version) == 5 ) { //If string retrieved is exactly 5 chars then continue
+    if (mb_strlen($server_version) == 5 ) { //If string retrieved is exactly 5 chars then continue
         if (version_compare($server_version, $version, '>')) $messages = "MiniGal Nano $server_version is available! <a href='http://www.minigal.dk/minigal-nano.html' target='_blank'>Get it now</a>";
     }
     fclose($file);
 }
 
+mb_internal_encoding("UTF-8");
 if (!defined("GALLERY_ROOT")) define("GALLERY_ROOT", "");
 $thumbdir = rtrim('photos' . "/" .$_REQUEST["dir"],"/");
 $thumbdir = str_replace("/..", "", $thumbdir); // Prevent looking at any up-level folders
@@ -152,7 +153,7 @@ $dirs = array();
 // 1. LOAD FOLDERS
         if (is_directory($currentdir . "/" . $file))
             {
-                if ($file != "." && $file != ".." )
+                if ($file != "." && $file != ".." && mb_substr($file, 0, 1) != ".")
                 {
                     checkpermissions($currentdir . "/" . $file); // Check for correct file permission
                     // Set thumbnail to folder.jpg if found:
@@ -177,7 +178,7 @@ $dirs = array();
                             $dirs[] = array(
                                 "name" => $file,
                                 "date" => filemtime($currentdir . "/" . $file),
-                                "html" => "<li><a href='?dir=" . ltrim($_GET['dir'] . "/" . $file, "/") . "'><em>" . padstring($file) . "</em><span></span><img src='" . GALLERY_ROOT . "images/folder_" . strtolower($folder_color) . ".png' width='$thumb_size' height='$thumb_size' alt='$label_loading' /></a></li>");
+                                "html" => "<li><a href='?dir=" . ltrim($_GET['dir'] . "/" . $file, "/") . "'><em>" . padstring($file) . "</em><span></span><img src='" . GALLERY_ROOT . "images/folder_" . mb_strtolower($folder_color) . ".png' width='$thumb_size' height='$thumb_size' alt='$label_loading' /></a></li>");
                         }
                     }
                 }
@@ -201,7 +202,7 @@ if (file_exists($currentdir ."/captions.txt"))
 }
 
 // 3. LOAD FILES
-                if ($file != "." && $file != ".." && $file != "folder.jpg")
+                if ($file != "." && $file != ".." && $file != "folder.jpg" && mb_substr($file, 0, 1) != ".")
                 {
                     // JPG, GIF and PNG
                     if (preg_match("/.jpg$|.gif$|.png$/i", $file))
@@ -216,6 +217,17 @@ if (file_exists($currentdir ."/captions.txt"))
                             "date" => filemtime($currentdir . "/" . $file),
                             "size" => filesize($currentdir . "/" . $file),
                             "html" => "<li><a href='createsmall.php?filename=" . $currentdir . "/" . $file . "&amp;size=$small_size' rel='lightbox[billeder]' title='$img_captions[$file]'><span></span><img src='" . GALLERY_ROOT . "createthumb.php?filename=" . $thumbdir . "/" . $file . "&amp;size=$thumb_size' alt='$label_loading' /></a></li>");
+                    }
+                    // MP4
+                    else if (preg_match("/.mp4$/i", $file))
+                    {
+                        $img_captions[$file] .= "<a href=\"" . $currentdir . "/" . $file . "\">original</a>\n";
+                        checkpermissions($currentdir . "/" . $file);
+                        $files[] = array (
+                            "name" => $file,
+                            "date" => filemtime($currentdir . "/" . $file),
+                            "size" => filesize($currentdir . "/" . $file),
+                            "html" => "<li><a href='" . $currentdir . "/" . $file . "&amp;size=$small_size' rel='lightbox[billeder]' title='$img_captions[$file]'><span></span><img src='" . GALLERY_ROOT . "createthumb.php?filename=" . $thumbdir . "/" . $file . "&amp;size=$thumb_size' alt='$label_loading' /></a></li>");
                     }
                     // Other filetypes
                     $extension = "";
@@ -249,10 +261,10 @@ if (sizeof($dirs) > 0)
     foreach ($dirs as $key => $row)
     {
         if($row["name"] == "") unset($dirs[$key]); //Delete empty array entries
-        $name[$key] = strtolower($row['name']);
-        $date[$key] = strtolower($row['date']);
+        $name[$key] = mb_strtolower($row['name']);
+        $date[$key] = mb_strtolower($row['date']);
     }
-    if (strtoupper($sortdir_folders) == "DESC") array_multisort($$sorting_folders, SORT_DESC, $name, SORT_DESC, $dirs);
+    if (mb_strtoupper($sortdir_folders) == "DESC") array_multisort($$sorting_folders, SORT_DESC, $name, SORT_DESC, $dirs);
     else array_multisort($$sorting_folders, SORT_ASC, $name, SORT_ASC, $dirs);
 }
 if (sizeof($files) > 0)
@@ -260,11 +272,11 @@ if (sizeof($files) > 0)
     foreach ($files as $key => $row)
     {
         if($row["name"] == "") unset($files[$key]); //Delete empty array entries
-        $name[$key] = strtolower($row['name']);
-        $date[$key] = strtolower($row['date']);
-        $size[$key] = strtolower($row['size']);
+        $name[$key] = mb_strtolower($row['name']);
+        $date[$key] = mb_strtolower($row['date']);
+        $size[$key] = mb_strtolower($row['size']);
     }
-    if (strtoupper($sortdir_files) == "DESC") array_multisort($$sorting_files, SORT_DESC, $name, SORT_ASC, $files);
+    if (mb_strtoupper($sortdir_files) == "DESC") array_multisort($$sorting_files, SORT_DESC, $name, SORT_ASC, $files);
     else array_multisort($$sorting_files, SORT_ASC, $name, SORT_ASC, $files);
 }
 

--- a/src/js/mediaboxAdv-1.3.4b.js
+++ b/src/js/mediaboxAdv-1.3.4b.js
@@ -95,13 +95,13 @@ var Mediabox;
 				bgcolor: '#000000',			// Background color, used for flash and QT media
 				wmode: 'opaque',			// Background setting for Adobe Flash ('opaque' and 'transparent' are most common)
 //			NonverBlaster
-				useNB: true,				// use NonverBlaster (true) or JW Media Player (false) for .flv and .mp4 files
-				playerpath: '/js/NonverBlaster.swf',	// Path to NonverBlaster.swf
+				useNB: false,				// use NonverBlaster (true) or JW Media Player (false) for .flv and .mp4 files
+				playerpath: 'NonverBlaster.swf',	// Path to NonverBlaster.swf
 				controlColor: '0xFFFFFF',	// set the controlbar color
 				controlBackColor: '0x000000',	// set the controlbar color
 				showTimecode: 'false',		// turn timecode display off or on
 //			JW Media Player settings and options
-				JWplayerpath: '/js/player.swf',	// Path to the mediaplayer.swf or flvplayer.swf file
+				JWplayerpath: 'player.swf',	// Path to the mediaplayer.swf or flvplayer.swf file
 				backcolor:	'000000',		// Base color for the controller, color name / hex value (0x000000)
 				frontcolor: '999999',		// Text and button color for the controller, color name / hex value (0x000000)
 				lightcolor: '000000',		// Rollover color for the controller, color name / hex value (0x000000)
@@ -345,6 +345,21 @@ var Mediabox;
 				preload = new Image();
 				preload.onload = startEffect;
 				preload.src = URL;
+// HTML5 Video
+			} else if (URL.match(/\.mts|\.mp4|\.avi/i)) {
+				mediaType = 'video';
+				mediaWidth = mediaWidth || options.defaultWidth;
+				mediaHeight = mediaHeight || options.defaultHeight;
+				mediaId = "mediaId_"+new Date().getTime();	// Safari may not update iframe content with a static id.
+				preload = new Element('video', {
+					'src': URL,
+					'id': mediaId,
+					'width': mediaWidth,
+					'height': mediaHeight,
+					'frameborder': 0,
+					'controls': 1
+					});
+				startEffect();
 // FLV, MP4
 			} else if (URL.match(/\.flv|\.mp4/i) || mediaType == 'video') {
 				mediaType = 'obj';
@@ -358,7 +373,7 @@ var Mediabox;
 					params: {wmode: options.wmode, bgcolor: options.bgcolor, allowscriptaccess: options.scriptaccess, allowfullscreen: options.fullscreen}
 					});
 				} else {
-				preload = new Swiff(''+options.JWplayerpath+'?file='+URL+'&backcolor='+options.backcolor+'&frontcolor='+options.frontcolor+'&lightcolor='+options.lightcolor+'&screencolor='+options.screencolor+'&autostart='+options.autoplay+'&controlbar='+options.controlbar, {
+				preload = new Swiff(''+options.JWplayerpath+'?v1.3.5&skin=mySkin.swf&video='+encodeURI(URL), {
 					id: 'MediaboxSWF',
 					width: mediaWidth,
 					height: mediaHeight,
@@ -384,7 +399,8 @@ var Mediabox;
 					params: {wmode: options.wmode, bgcolor: options.bgcolor, allowscriptaccess: options.scriptaccess, allowfullscreen: options.fullscreen}
 					});
 				} else {
-				preload = new Swiff(''+options.JWplayerpath+'?file='+URL+'&backcolor='+options.backcolor+'&frontcolor='+options.frontcolor+'&lightcolor='+options.lightcolor+'&screencolor='+options.screencolor+'&autostart='+options.autoplay, {
+//				preload = new Swiff(''+options.JWplayerpath+'?file='+URL+'&backcolor='+options.backcolor+'&frontcolor='+options.frontcolor+'&lightcolor='+options.lightcolor+'&screencolor='+options.screencolor+'&autostart='+options.autoplay, {
+				preload = new Swiff(''+options.JWplayerpath+'?v1.3.5&skin=mySkin.swf&video='+encodeURI(URL), {
 					id: 'MediaboxSWF',
 					width: mediaWidth,
 					height: mediaHeight,
@@ -883,6 +899,9 @@ var Mediabox;
 			image.setStyles({backgroundImage: "none", display: ""});
 			image.set('html', preload);
 		} else if (mediaType == "url") {
+			image.setStyles({backgroundImage: "none", display: ""});
+			preload.inject(image);
+		} else if (mediaType == "video") {
 			image.setStyles({backgroundImage: "none", display: ""});
 			preload.inject(image);
 		} else {

--- a/src/system_check.php
+++ b/src/system_check.php
@@ -1,5 +1,5 @@
 <?php
-ini_set("memory_limit","256M");
+ini_set("memory_limit","512M");
 
 $exif = "No";
 $gd = "No";


### PR DESCRIPTION
Hi,

I too had customized minigal nano for my own needs and have merged my changes with yours. I hope you would find it useful.

1. Added HTML5 video support for .mp4 files with ffmpegthumbnailer as thumbnail backend (new featute)
2. Added support for hidden images and directories whose filename starts with a dot (.) (new feature)
3. Fixed thumbnail Content-type header for the error images and png thumbnails (bug fix)
4. Fixed Unicode support (bug fix)
5. Fixed pah traversal and input variable filtering in createthumb.php script (security)
6. Moved cache dir to /tmp out of the http server tree (security)
7. Fixed cache renewal if a different thumbnail size is requested (bug fix)

Note that the cache location and thumb file names have changed.

Signed-off-by: Denis Shulyaka <Shulyaka@gmail.com>